### PR TITLE
avoid twitter object conversion and memoization

### DIFF
--- a/feeder.rb
+++ b/feeder.rb
@@ -85,9 +85,9 @@ EventMachine.run do
     end
 
     # update redis for each matched char
-    status.emojis.each do |matched_emoji|
+    status.emojis().each do |matched_emoji|
       cp = matched_emoji.unified
-      REDIS.evalsha(sha, [], [cp, status.tiny_json])
+      REDIS.evalsha(sha, [], [cp, status.tiny_json()])
     end
   end
 

--- a/lib/wrapped_tweet.rb
+++ b/lib/wrapped_tweet.rb
@@ -41,20 +41,20 @@ module WrappedTweet
 
   # memoized cache of ensmallenified json
   def tiny_json
-    @small_json ||= Oj.dump(self.ensmallen)
+    Oj.dump(self.ensmallen)
   end
 
   # return all the emoji chars contained in the tweet, as EmojiData::EmojiChar
   # dedupe since we only want to count each emoji once per tweet
   def emojis
-    @emojis ||= EmojiData.find_by_str(self.text).uniq { |e| e.unified }
+    EmojiData.find_by_str(self.text).uniq { |e| e.unified }
   end
 
   protected
   # twitter seems to have a bug where usernames can get null bytes set in string
   # this strips them out so we dont cause string parse errors
   def safe_user_name
-    @safe_name ||= self.user.name.gsub(/\0/, '')
+    self.user.name.gsub(/\0/, '')
   end
 
   def html_link(text, url)

--- a/lib/wrapped_tweet.rb
+++ b/lib/wrapped_tweet.rb
@@ -13,12 +13,12 @@ module WrappedTweet
   # (what? it's a perfectly cromulent word.)
   def ensmallen
     {
-      'id'                  => self.id.to_s,
+      'id'                  => self.attrs[:id_str],
       'text'                => self.text,
       'screen_name'         => self.user.screen_name,
       'name'                => self.safe_user_name(),
       'links'               => self.ensmallen_links(),
-      'profile_image_url'   => self.user.profile_image_url.to_s,
+      'profile_image_url'   => self.user.attrs[:profile_image_url],
       'created_at'          => self.created_at.iso8601
     }
   end
@@ -28,9 +28,9 @@ module WrappedTweet
   def ensmallen_links
     links = (self.urls + self.media).map do |link|
       {
-        'url'          => link.url.to_s,
-        'display_url'  => link.display_url.to_s,
-        'expanded_url' => link.expanded_url.to_s,
+        'url'          => link.attrs[:url],
+        'display_url'  => link.attrs[:display_url],
+        'expanded_url' => link.attrs[:expanded_url],
         'indices'      => link.indices
       }
     end

--- a/lib/wrapped_tweet.rb
+++ b/lib/wrapped_tweet.rb
@@ -44,13 +44,6 @@ module WrappedTweet
     @small_json ||= Oj.dump(self.ensmallen)
   end
 
-  # return all the emoji chars contained in the tweet
-  # TODO: deprecate and remove me, dont appear to be using anywhere and  will
-  # probably having unexpected behavior with the variant encoding change.
-  def emoji_chars
-    @emoji_chars ||= self.emojis.map { |e| e.char }
-  end
-
   # return all the emoji chars contained in the tweet, as EmojiData::EmojiChar
   # dedupe since we only want to count each emoji once per tweet
   def emojis


### PR DESCRIPTION
Reminder that twitter gem replaces URL and Timestamp access fields with methods that convert to native Ruby objects and then memorizes them.  Since we're just replacing these with a `.to_s` anyhow, we should avoid this since it's needless conversion back and forth, and profiling suggests that this is where the majority of our local processing time is spent.

Need to figure out the "official" way to get these attr fields directly as strings that is API stable.

(Not high priority since the bigger CPU load at current time is coming from IO with twitter streaming API and reds, but this is some low hanging fruit when we want to shave a few percentage points.)